### PR TITLE
#5 setting project root als env var in setup script

### DIFF
--- a/bin/install_terraform_cli.sh
+++ b/bin/install_terraform_cli.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env/ bash
 
+PROJECT_ROOT='/workspace/terraform-beginner-bootcamp-2023'
+cd ..
 sudo apt-get update && sudo apt-get install -y gnupg software-properties-common curl
 
 wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor | sudo tee /usr/share/keyrings/hashicorp-archive-keyring.gpg
@@ -15,3 +17,5 @@ sudo tee /etc/apt/sources.list.d/hashicorp.list
 sudo apt update
 
 sudo apt-get install terraform -y
+
+cd $PROJECT_ROOT


### PR DESCRIPTION
Done, env var PROJCECT_ROOT now contains project root folder